### PR TITLE
Fix Google response error

### DIFF
--- a/tasks/webstore_upload.js
+++ b/tasks/webstore_upload.js
@@ -176,22 +176,14 @@ module.exports = function (grunt) {
                     response += chunk;
                 });
                 res.on('end', function () {
-                    var hasError = false;
-                    var error = {};
                     var obj = JSON.parse(response);
-                    if( obj.uploadState !== "SUCCESS" ){
+                    if( obj.uploadState !== "SUCCESS" ) {
                         // console.log('Error while uploading ZIP', obj);
-                        hasError = true;
-                        error[obj.id] = obj.itemError;
+                        d.reject(obj.error.message);
                     }else{
                         grunt.log.writeln(' ');
                         grunt.log.writeln('Uploading done ('+ options.name +')' );
                         grunt.log.writeln(' ');
-                    }
-
-                    if( hasError ){
-                        d.reject(error);
-                    }else{
                         if( doPublish ){
                             publishItem( options ).then(function () {
                                 d.resolve();


### PR DESCRIPTION
The Google error response looks like this:

``` json
{ error:
   { errors: [ [Object] ],
     code: 403,
     message: "Access Not Configured. The API is not enabled for your project, or there is a per-IP or per-Referer restriction configured on your API key and the request does not match these restrictions. Please use the Google Developers Console to update your configuration."
  }
 }
```

this PR uses this format, so we do not get a

``` console
error while uploading:  { undefined: undefined }
```

in the console.
