### PR TITLE
Adds the ability to specify a `refresh_token` to fully automate uploads for CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ grunt.loadNpmTasks('grunt-webstore-upload');
 ### Overview
 Read more about great ability to automate this task here: [Chrome Web Store Publish API](http://developer.chrome.com/webstore/using_webstore_api).
 In your project's Gruntfile, add a section named `webstore_upload` to the data object passed into `grunt.initConfig()`.
-#### Please noty, that you have to upload your extension first time manually, and then provide appID to update ( see below ). Also please make sure, that your draft ready to be published, ie all required fields was populated
+#### Please note, that you have to upload your extension first time manually, and then provide appID to update ( see below ). Also please make sure, that your draft ready to be published, ie all required fields was populated
 
 ```js
 grunt.initConfig({
@@ -32,6 +32,12 @@ grunt.initConfig({
                 publish: true, //publish item right after uploading. default false
                 client_id: "ie204es2mninvnb.apps.googleusercontent.com",
                 client_secret: "LEJDeBHfS"
+            },
+            "other_account": {
+                publish: true, //publish item right after uploading. default false
+                client_id: "ie204es2mninvnb.apps.googleusercontent.com",
+                client_secret: "LEJDeBHfS",
+                refresh_token: "1/eeeeeeeeeeeeeeeeeeeeeee_aaaaaaaaaaaaaaaaaaa"
             },
             "new_account": { 
                 cli_auth: true, // Use server-less cli prompt go get access token. Default false
@@ -105,6 +111,14 @@ Type: `String`
 
 Required
 
+#### refresh_token
+[How to get it](http://developer.chrome.com/webstore/using_webstore_api#beforeyoubegin)
+Refresh token for the Chrome Console API
+
+Type: `String`
+
+Optional
+
 
 ### Extensions
 It is object with arbitrary meaningful extensions names as a keys (see example above).
@@ -168,6 +182,9 @@ Read more about [Chrome Web Store Publish API](http://developer.chrome.com/webst
 + browser should be opened
 + confirm privileges in browser ( we have to manually do this )
 + wait until uploading will be finished
+
+To automatically pull a new access token using a refresh token just set the `refresh_token` property in your configuration.  If the `refresh_token` is present
+it will automatically refresh the token for you without any manual intervention.
 
 
 ## Contributing

--- a/tasks/webstore_upload.js
+++ b/tasks/webstore_upload.js
@@ -61,6 +61,63 @@ module.exports = function (grunt) {
                 });
             });
 
+        grunt.registerTask( 'refresh_account_token', 'Refresh token for account',
+          function(accountName){
+              //prepare account for inner function
+              var account = accounts[ accountName ];
+              account["name"] = accountName;
+
+              var done = this.async();
+
+              grunt.log.writeln('Refreshing access token.');
+              var post_data = util.format('client_id=%s' +
+                '&client_secret=%s' +
+                '&refresh_token=%s' +
+                '&grant_type=refresh_token',
+                account.client_id,
+                account.client_secret,
+                account.refresh_token);
+
+              var req = https.request({
+                  host: 'accounts.google.com',
+                  path: '/o/oauth2/token',
+                  method: 'POST',
+                  headers: {
+                      'Content-Type': 'application/x-www-form-urlencoded',
+                      'Content-Length': post_data.length
+                  }
+              }, function(res) {
+
+                  res.setEncoding('utf8');
+                  var response = '';
+                  res.on('data', function (chunk) {
+                      response += chunk;
+                  });
+                  res.on('end', function () {
+                      var obj = JSON.parse(response);
+                      if(obj.error){
+                          grunt.log.writeln('Error: during access token request');
+                          grunt.log.writeln( response );
+                          done( new Error() );
+                      }else{
+                          var token = obj.access_token;
+                          //set token for provided account
+                          accounts[ accountName ].token = token;
+                          done();
+                      }
+                  });
+              });
+
+              req.on('error', function(e){
+                  console.log('Something went wrong', e.message);
+                  cb( e );
+              });
+
+              req.write( post_data );
+              req.end();
+
+          });
+
         grunt.registerTask( 'uploading', 'uploading with token',
             function( extensionName ){
                 var done = this.async();
@@ -114,6 +171,7 @@ module.exports = function (grunt) {
                 });
             });
 
+
         if(taskName){
             //upload specific extension
             var extensionConfigPath = extensionsConfigPath + '.' + taskName;
@@ -125,7 +183,14 @@ module.exports = function (grunt) {
             var extensionConfig = grunt.config(extensionConfigPath);
             var accountName = extensionConfig.account || "default";
 
-            grunt.task.run( [ "get_account_token:" + accountName, "uploading:" + taskName ] );
+            var account = accounts[ accountName ];
+
+            // If a `refresh_token` exists in the config then use it instead of prompting the user
+            var tokenStrategy = account.refresh_token !== undefined
+              ? 'refresh_account_token:'
+              : 'get_account_token:';
+
+            grunt.task.run( [ tokenStrategy + accountName, "uploading:" + taskName ] );
 
         }else{
             //upload all available extensions
@@ -133,7 +198,16 @@ module.exports = function (grunt) {
 
             //callculate tasks for accounts that we want to use
             var accountsTasksToUse = _.uniq( _.map( extensions, function (extension) {
-                return "get_account_token:" + (extension.account || "default");
+
+                var name = (extension.account || "default");
+                var account = accounts[ name ];
+
+                // If a `refresh_token` exists in the config then use it instead of prompting the user
+                var tokenStrategy = account.refresh_token !== undefined
+                  ? 'refresh_account_token:'
+                  : 'get_account_token:';
+
+                return tokenStrategy + name;
             }) );
 
             accountsTasksToUse.push('uploading');

--- a/tasks/webstore_upload.js
+++ b/tasks/webstore_upload.js
@@ -110,7 +110,7 @@ module.exports = function (grunt) {
 
               req.on('error', function(e){
                   console.log('Something went wrong', e.message);
-                  cb( e );
+                  done( e );
               });
 
               req.write( post_data );


### PR DESCRIPTION
This PR adds a new task called `refresh_account_token` that allows for the configuration to specify a refresh token that can be used to fully automate the upload.  If the refresh token exists it is automatically used rather than spin up the server.  See the updates to the README for how to configure.

Our use case is that we want to fully automate uploading our nightly builds to the Chrome webstore so they're ready for our beta testers the next day without any manual work.  We were previously using some custom python scripts to do this but want to unify our ecosystem to be fully JS.