### PR TITLE
Help user get refresh token

### DIFF
--- a/tasks/webstore_upload.js
+++ b/tasks/webstore_upload.js
@@ -64,7 +64,16 @@ module.exports = function (grunt) {
             accounts = grunt.config(accountsConfigPath);
             var extensionsToUpload = extensions;
             if(tasks.length){
-                extensionsToUpload = _.pick(extensions, tasks)
+                //validate extension name
+                _.each(tasks, function(task){
+                    if( !extensionsToUpload[task] ){
+                        var msg = 'Configuration for "' +
+                            task
+                            + '" not exist, please check configuration of the extensions list';
+                        grunt.fail.warn(msg);
+                    }
+                });
+                extensionsToUpload = _.pick(extensions, tasks);
             }
 
             grunt.registerTask( 'get_account_token', 'Get token for account',
@@ -409,6 +418,9 @@ module.exports = function (grunt) {
                         grunt.log.writeln( response );
                         cb( new Error() );
                     }else{
+                    	if (!account.refresh_token) {
+	                    	grunt.log.writeln('To make future uploads work without needing the browser, add this to your account settings in the Gruntfile:\n  refresh_token: "' + obj.refresh_token + '"');
+                    	}
                         cb(null, obj.access_token);
                     }
                 });

--- a/tasks/webstore_upload.js
+++ b/tasks/webstore_upload.js
@@ -64,7 +64,7 @@ module.exports = function (grunt) {
             accounts = grunt.config(accountsConfigPath);
             var extensionsToUpload = extensions;
             if(tasks.length){
-            	extensionsToUpload = _.pick(extensions, tasks)
+        	    extensionsToUpload = _.pick(extensions, tasks)
             }
 
             grunt.registerTask( 'get_account_token', 'Get token for account',

--- a/tasks/webstore_upload.js
+++ b/tasks/webstore_upload.js
@@ -64,7 +64,7 @@ module.exports = function (grunt) {
             accounts = grunt.config(accountsConfigPath);
             var extensionsToUpload = extensions;
             if(tasks.length){
-        	    extensionsToUpload = _.pick(extensions, tasks)
+                extensionsToUpload = _.pick(extensions, tasks)
             }
 
             grunt.registerTask( 'get_account_token', 'Get token for account',

--- a/tasks/webstore_upload.js
+++ b/tasks/webstore_upload.js
@@ -64,16 +64,7 @@ module.exports = function (grunt) {
             accounts = grunt.config(accountsConfigPath);
             var extensionsToUpload = extensions;
             if(tasks.length){
-                //validate extension name
-                _.each(tasks, function(task){
-                    if( !extensionsToUpload[task] ){
-                        var msg = 'Configuration for "' +
-                            task
-                            + '" not exist, please check configuration of the extensions list';
-                        grunt.fail.warn(msg);
-                    }
-                });
-                extensionsToUpload = _.pick(extensions, tasks);
+            	extensionsToUpload = _.pick(extensions, tasks)
             }
 
             grunt.registerTask( 'get_account_token', 'Get token for account',


### PR DESCRIPTION
This PR outputs the refresh token to the console, helping users that only have client id and secret in the config get rid of the manual step to authorize the Oauth token in the browser